### PR TITLE
cleaning up android manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,14 +5,6 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
-    <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
-    <uses-permission android:name="android.permission.READ_CONTACTS"/>
-    <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
-    <uses-permission android:name="android.permission.READ_PROFILE"/>
-    <uses-permission android:name="android.permission.NFC"/>
-
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
@@ -28,7 +20,6 @@
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
@@ -43,28 +34,13 @@
         <activity
             android:name=".UserDetailActivity"
             android:label="User Detail">
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
-
-                <category android:name="android.intent.category.DEFAULT"/>
-
-                <data android:mimeType="application/vnd.co.touchlab.droidconandroid"/>
-            </intent-filter>
         </activity>
 
         <activity
             android:name=".EventDetailActivity"
             android:parentActivityName=".ScheduleActivity"/>
 
-        <meta-data
-            android:name="android.support.PARENT_ACTIVITY"
-            android:value=".ScheduleActivity"/>
-
         <activity android:name=".WelcomeActivity"/>
-
-        <service
-            android:name="co.touchlab.android.threading.tasks.helper.KeepAliveService"
-            android:exported="true"/>
 
         <service
             android:name=".shared.tasks.persisted.JobQueueService"
@@ -87,13 +63,6 @@
             </intent-filter>
         </receiver>
 
-        <meta-data
-            android:name="JW_LICENSE_KEY"
-            android:value="@string/jw_license_key"/>
-
-        <activity android:name=".VideoActivity"
-                  android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
-        </activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
Removing unused permissions. This should also resolve ScheduleActivity crash - there was a metadata for parent activity ScheduleActivity in <application>