### PR TITLE
ios firebase notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ captures/
 
 # Google Play Services
 google-services.json
+GoogleService-Info.plist
 
 # Keystore files
 *.jks

--- a/app/src/main/kotlin/co/touchlab/droidconandroid/alerts/NotificationService.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/alerts/NotificationService.kt
@@ -82,7 +82,7 @@ class NotificationService : FirebaseMessagingService() {
 
     private fun sendIntentNotification(notification: RemoteMessage.Notification, intent: Intent, channelId: String) {
         val title = if (notification.title.isNullOrBlank()) getString(R.string.app_name) else notification.title
-        val message = notification.body!!
+        val message = if (notification.body.isNullOrBlank()) getString(R.string.version_message) else notification.body
 
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         val pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="general_description">Important updates from Droidcon</string>
     <string name="version_name">Version Update</string>
     <string name="version_description">Know when new versions of the app are released</string>
+    <string name="version_message">A new version of the app is now available!</string>
     <string name="event_name">Upcoming Events</string>
     <string name="event_description">Reminders for upcoming events</string>
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -19,6 +19,7 @@ target 'ios' do
 
   # Pods for ios
     pod 'Firebase'
+    pod 'Firebase/Messaging'
 
   target 'iosTests' do
     inherit! :search_paths

--- a/ios/ios.xcodeproj/project.pbxproj
+++ b/ios/ios.xcodeproj/project.pbxproj
@@ -2890,10 +2890,10 @@
 		013AE4EB1F3A3D6400C91182 /* ComGoogleGsonGsonBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ComGoogleGsonGsonBuilder.m; sourceTree = "<group>"; };
 		013AE4EC1F3A3D6400C91182 /* ComGoogleGsonInstanceCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComGoogleGsonInstanceCreator.h; sourceTree = "<group>"; };
 		013AE4ED1F3A3D6400C91182 /* ComGoogleGsonInstanceCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ComGoogleGsonInstanceCreator.m; sourceTree = "<group>"; };
-		013AE4EE1F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Preconditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComGoogleGsonInternal$Gson$Preconditions.h; sourceTree = "<group>"; };
-		013AE4EF1F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Preconditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ComGoogleGsonInternal$Gson$Preconditions.m; sourceTree = "<group>"; };
-		013AE4F01F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComGoogleGsonInternal$Gson$Types.h; sourceTree = "<group>"; };
-		013AE4F11F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Types.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ComGoogleGsonInternal$Gson$Types.m; sourceTree = "<group>"; };
+		013AE4EE1F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Preconditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ComGoogleGsonInternal$Gson$Preconditions.h"; sourceTree = "<group>"; };
+		013AE4EF1F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Preconditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ComGoogleGsonInternal$Gson$Preconditions.m"; sourceTree = "<group>"; };
+		013AE4F01F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ComGoogleGsonInternal$Gson$Types.h"; sourceTree = "<group>"; };
+		013AE4F11F3A3D6400C91182 /* ComGoogleGsonInternal$Gson$Types.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ComGoogleGsonInternal$Gson$Types.m"; sourceTree = "<group>"; };
 		013AE4F21F3A3D6400C91182 /* ComGoogleGsonInternalBindArrayTypeAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComGoogleGsonInternalBindArrayTypeAdapter.h; sourceTree = "<group>"; };
 		013AE4F31F3A3D6400C91182 /* ComGoogleGsonInternalBindArrayTypeAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ComGoogleGsonInternalBindArrayTypeAdapter.m; sourceTree = "<group>"; };
 		013AE4F41F3A3D6400C91182 /* ComGoogleGsonInternalBindCollectionTypeAdapterFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComGoogleGsonInternalBindCollectionTypeAdapterFactory.h; sourceTree = "<group>"; };
@@ -10001,13 +10001,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-iosUITests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3D37BFCB66229BC15B176609 /* [CP] Check Pods Manifest.lock */ = {
@@ -10016,13 +10019,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-iosTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		4ADFA7188E05A380D7FB1124 /* [CP] Check Pods Manifest.lock */ = {
@@ -10135,13 +10141,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ios-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B0B01C04F37E110A39AD9EDE /* [CP] Check Pods Manifest.lock */ = {
@@ -10150,13 +10159,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-dcframework-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B9F9E5CDCDC085164D821BBC /* [CP] Copy Pods Resources */ = {
@@ -10195,9 +10207,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -10225,13 +10244,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-dcframeworkTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EB97482FEF65C7B46258CA87 /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/ios.xcodeproj/project.pbxproj
+++ b/ios/ios.xcodeproj/project.pbxproj
@@ -2657,6 +2657,8 @@
 		FA6128C31C986E7A001142E8 /* EventTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6128C21C986E7A001142E8 /* EventTableViewCell.xib */; };
 		FA6128C51C986E87001142E8 /* EventTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6128C41C986E87001142E8 /* EventTableViewCell.swift */; };
 		FAE033A61C974C65001C50E1 /* EventDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE033A51C974C65001C50E1 /* EventDetailViewController.swift */; };
+		FB0055F21F45ECCA005B1B8D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FB0055F11F45ECCA005B1B8D /* GoogleService-Info.plist */; };
+		FB4869F41F46469C002065CE /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB4869F31F46469C002065CE /* TimeUtils.swift */; };
 		FBB8D9191F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = FBB8D9171F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.h */; };
 		FBB8D91A1F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = FBB8D9181F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.m */; };
 		FBD247BD1F3E406800E48171 /* JavaUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD247BC1F3E406800E48171 /* JavaUtils.swift */; };
@@ -5339,7 +5341,7 @@
 		4C81B70E1D76162000DFB89C /* SponsorPhotoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SponsorPhotoCell.swift; sourceTree = "<group>"; };
 		4C81B7121D7616C500DFB89C /* SponsorsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SponsorsViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		55F54A492D46D70B0A7D6257 /* Pods_dcframeworkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_dcframeworkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		631B98EB1C7D6533008AA20D /* Droicon NYC 2016.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Droicon NYC 2016.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		631B98EB1C7D6533008AA20D /* Droidcon 17 anon.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Droidcon 17 anon.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		631B98F81C7D6533008AA20D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		631B98FA1C7D6533008AA20D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		631B98FF1C7D6533008AA20D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -5383,9 +5385,12 @@
 		FA6128C41C986E87001142E8 /* EventTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTableViewCell.swift; sourceTree = "<group>"; };
 		FA86A7F91C92169900C09CE7 /* ios-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ios-Bridging-Header.h"; sourceTree = "<group>"; };
 		FAE033A51C974C65001C50E1 /* EventDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDetailViewController.swift; sourceTree = "<group>"; };
+		FB0055F11F45ECCA005B1B8D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Desktop/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		FB4869F31F46469C002065CE /* TimeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
 		FBB8D9171F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAGNetworkModule_ProvidesRsvpRequestFactory.h; sourceTree = "<group>"; };
 		FBB8D9181F43762300614C8D /* DDAGNetworkModule_ProvidesRsvpRequestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDAGNetworkModule_ProvidesRsvpRequestFactory.m; sourceTree = "<group>"; };
 		FBD247BC1F3E406800E48171 /* JavaUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JavaUtils.swift; sourceTree = "<group>"; };
+		FBE971831F44E42100487A6A /* Droicon NYC 2016.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Droicon NYC 2016.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -8264,7 +8269,7 @@
 		631B98EC1C7D6533008AA20D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				631B98EB1C7D6533008AA20D /* Droicon NYC 2016.app */,
+				631B98EB1C7D6533008AA20D /* Droidcon 17 anon.app */,
 				631B99041C7D6533008AA20D /* iosTests.xctest */,
 				631B990F1C7D6533008AA20D /* iosUITests.xctest */,
 				6342B6AD1DC6A18A0060BE83 /* dcframework.framework */,
@@ -8276,13 +8281,15 @@
 		631B98ED1C7D6533008AA20D /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				FBE971831F44E42100487A6A /* Droicon NYC 2016.entitlements */,
 				018320271F153CC3009794AC /* AppDelegate.swift */,
+				FBD247BC1F3E406800E48171 /* JavaUtils.swift */,
+				FB4869F31F46469C002065CE /* TimeUtils.swift */,
 				639320301D77FF700047224B /* dataseeds */,
 				631B98FF1C7D6533008AA20D /* Info.plist */,
 				F9D6952C1D47AF9D0095F0F9 /* AboutViewController.swift */,
 				F9903FA11D3FBEC70050687E /* DroidconTabBarViewController.swift */,
 				FAE033A51C974C65001C50E1 /* EventDetailViewController.swift */,
-				FBD247BC1F3E406800E48171 /* JavaUtils.swift */,
 				63EE30CD1CC6985800B64D3D /* LaunchViewController.swift */,
 				63EE30DE1CD025AC00B64D3D /* ScheduleListCell.swift */,
 				018320251F152215009794AC /* ScheduleViewController.swift */,
@@ -8292,6 +8299,7 @@
 				0183202D1F155F9A009794AC /* UIViewController.swift */,
 				F92EB6591D5A5EEC003B47B7 /* WelcomePageViewController.swift */,
 				63EE30CF1CC6AD4400B64D3D /* WelcomeViewController.swift */,
+				FB0055F11F45ECCA005B1B8D /* GoogleService-Info.plist */,
 				631B98FA1C7D6533008AA20D /* Assets.xcassets */,
 				631B98F71C7D6533008AA20D /* Main.storyboard */,
 				631B98EE1C7D6533008AA20D /* Supporting Files */,
@@ -9723,7 +9731,7 @@
 			);
 			name = ios;
 			productName = ios;
-			productReference = 631B98EB1C7D6533008AA20D /* Droicon NYC 2016.app */;
+			productReference = 631B98EB1C7D6533008AA20D /* Droidcon 17 anon.app */;
 			productType = "com.apple.product-type.application";
 		};
 		631B99031C7D6533008AA20D /* iosTests */ = {
@@ -9829,8 +9837,14 @@
 				TargetAttributes = {
 					631B98EA1C7D6533008AA20D = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 7FYJJPTXQ8;
+						DevelopmentTeam = 2UER9BPG44;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
+						};
 					};
 					631B99031C7D6533008AA20D = {
 						CreatedOnToolsVersion = 7.2;
@@ -9843,7 +9857,6 @@
 					};
 					6342B6AC1DC6A18A0060BE83 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 7FYJJPTXQ8;
 						ProvisioningStyle = Automatic;
 					};
 					6342B6B41DC6A18B0060BE83 = {
@@ -9886,6 +9899,7 @@
 				FA6128C31C986E7A001142E8 /* EventTableViewCell.xib in Resources */,
 				631B98F91C7D6533008AA20D /* Main.storyboard in Resources */,
 				FA6128C11C986E16001142E8 /* SpeakerTableViewCell.xib in Resources */,
+				FB0055F21F45ECCA005B1B8D /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10273,6 +10287,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				018320281F153CC3009794AC /* AppDelegate.swift in Sources */,
+				FB4869F41F46469C002065CE /* TimeUtils.swift in Sources */,
 				63EE30DF1CD025AC00B64D3D /* ScheduleListCell.swift in Sources */,
 				0183202E1F155F9A009794AC /* UIViewController.swift in Sources */,
 				4C81B70B1D75E7B500DFB89C /* SponsorImage.swift in Sources */,
@@ -11759,11 +11774,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "ios/Droicon NYC 2016.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FYJJPTXQ8;
+				DEVELOPMENT_TEAM = 2UER9BPG44;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -11788,10 +11804,11 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.touchlab.ios.albany;
+				PRODUCT_BUNDLE_IDENTIFIER = co.touchlab.ios.anon;
 				PRODUCT_MODULE_NAME = ios;
-				PRODUCT_NAME = "Droicon NYC 2016";
+				PRODUCT_NAME = "Droidcon 17 anon";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ios/ios-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -11805,10 +11822,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "ios/Droicon NYC 2016.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FYJJPTXQ8;
+				DEVELOPMENT_TEAM = 2UER9BPG44;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -11833,10 +11851,11 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.touchlab.ios.albany;
+				PRODUCT_BUNDLE_IDENTIFIER = co.touchlab.ios.anon;
 				PRODUCT_MODULE_NAME = ios;
-				PRODUCT_NAME = "Droicon NYC 2016";
+				PRODUCT_NAME = "Droidcon 17 anon";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ios/ios-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 			};
@@ -11911,7 +11930,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FYJJPTXQ8;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -11957,7 +11976,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FYJJPTXQ8;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/ios/ios/AboutViewController.swift
+++ b/ios/ios/AboutViewController.swift
@@ -16,7 +16,6 @@ class AboutViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
         navBar.isTranslucent = false
     }
     

--- a/ios/ios/AppDelegate.swift
+++ b/ios/ios/AppDelegate.swift
@@ -140,11 +140,12 @@ extension AppDelegate : MessagingDelegate {
         sendNotification(content: content, trigger: trigger, notificationIdentifier: notificationIdentifier)
     }
     
-    func sendAlarmNotification(title: String, date: Date) {
+    func sendAlarmNotification(title: String, date: Date, eventId: String) {
         let content = UNMutableNotificationContent()
         content.title = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
         content.body = "The \(title) session is starting soon!"
         content.sound = UNNotificationSound.default()
+        content.userInfo = ["eventId": eventId]
         let triggerDate = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute,.second,], from: date)
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
         let notificationIdentifier = "eventNotification"

--- a/ios/ios/AppDelegate.swift
+++ b/ios/ios/AppDelegate.swift
@@ -91,7 +91,7 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         
         if identifier == "versionNotification" {
             UIApplication.shared.open(NSURL(string: "itms-apps://itunes.apple.com/us/app/droidcon-nyc-2016/id1155197664?mt=8")! as URL)
-        } else if data["type"] as? String == "event" {
+        } else if (data["type"] as? String == "event") || identifier == "eventNotification" {
             if let controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "EventDetail") as? EventDetailViewController {
                 if let window = self.window, let rootViewController = window.rootViewController {
                     var currentController = rootViewController
@@ -136,8 +136,23 @@ extension AppDelegate : MessagingDelegate {
         content.body = "A new version of the app is now available!"
         content.sound = UNNotificationSound.default()
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false)
-        let notificatoinIdentifier = "versionNotification"
-        let request = UNNotificationRequest(identifier: notificatoinIdentifier, content: content, trigger: trigger)
+        let notificationIdentifier = "versionNotification"
+        sendNotification(content: content, trigger: trigger, notificationIdentifier: notificationIdentifier)
+    }
+    
+    func sendAlarmNotification(title: String, date: Date) {
+        let content = UNMutableNotificationContent()
+        content.title = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
+        content.body = "The \(title) session is starting soon!"
+        content.sound = UNNotificationSound.default()
+        let triggerDate = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute,.second,], from: date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
+        let notificationIdentifier = "eventNotification"
+        sendNotification(content: content, trigger: trigger, notificationIdentifier: notificationIdentifier)
+    }
+    
+    func sendNotification(content: UNMutableNotificationContent, trigger: UNNotificationTrigger, notificationIdentifier: String) {
+        let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request) { (error) in
             print("Notification error: \(error as Any)")
         }

--- a/ios/ios/Base.lproj/Main.storyboard
+++ b/ios/ios/Base.lproj/Main.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,7 +36,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="75"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gju-G3-1je" id="gPi-ye-4bF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="74.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oQ-BT-1py">
@@ -732,7 +731,6 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pIs-iv-Rw5">
                                 <rect key="frame" x="-4" y="567" width="383" height="50"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="pIs-iv-Rw5" secondAttribute="height" multiplier="383:50" id="HLM-sv-QYi"/>
                                     <constraint firstAttribute="height" constant="50" id="HT6-YS-mPJ"/>
                                     <constraint firstAttribute="height" constant="50" id="teX-Uo-18a"/>
                                 </constraints>
@@ -887,7 +885,7 @@
         <image name="illo_welcome" width="360" height="360"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="pVg-yj-H2O"/>
+        <segue reference="gpQ-ie-VS3"/>
         <segue reference="G8c-Yr-iby"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.066666666666666666" green="0.30196078431372547" blue="0.85882352941176465" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/ios/ios/Droicon NYC 2016.entitlements
+++ b/ios/ios/Droicon NYC 2016.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/ios/ios/EventDetailViewController.swift
+++ b/ios/ios/EventDetailViewController.swift
@@ -17,10 +17,8 @@ import dcframework
     @IBOutlet weak var headerImage: UIImageView!
     
     // MARK: Properties
-    var titleString: String?
-    var descriptionString: String?
-    var dateTime: String?
     var event: DDATEvent!
+    var eventId: jlong!
     var conflict: jboolean!
     var speakers: [DDATUserAccount]?
     var eventDetailPresenter: DPRESEventDetailViewModel!
@@ -28,6 +26,7 @@ import dcframework
     // MARK: Lifecycle events
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
+        navigationItem.hidesBackButton = false
     }
     
     override func viewDidLoad() {
@@ -39,7 +38,7 @@ import dcframework
         
         eventDetailPresenter = DPRESEventDetailViewModel.forIos()
         eventDetailPresenter.register__(with: self)
-        eventDetailPresenter.getDetailsWithLong(event.getId())
+        eventDetailPresenter.getDetailsWithLong(eventId)
         
         tableView.estimatedRowHeight = tableView.rowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
@@ -53,8 +52,6 @@ import dcframework
         self.tableView.contentInset = UIEdgeInsets.zero
         self.tableView.separatorStyle = .none
         self.tableView.reloadData()
-        
-        styleButton()
     }
     
     deinit {
@@ -66,6 +63,7 @@ import dcframework
         event = eventInfo.getEvent()
         conflict = eventInfo.getConflict()
         speakers = JavaUtils.javaList(toList: eventInfo.getSpeakers()) as? [DDATUserAccount]
+        styleButton()
         updateAllUi()
     }
     
@@ -105,16 +103,18 @@ import dcframework
         if (indexPath as NSIndexPath).section == 0 {
             let cell:EventTableViewCell = tableView.dequeueReusableCell(withIdentifier: "eventCell") as! EventTableViewCell
             cell.descriptionLabel.numberOfLines = 0
-            cell.loadInfo(titleString!, description: descriptionString!, track: event!.getVenue().getName(), time: dateTime!, networkEvent: event, eventDetailPresenter: eventDetailPresenter, conflict: conflict)
+            if (event != nil) {
+                cell.loadInfo(event, eventDetailPresenter: eventDetailPresenter, conflict: conflict)
+            }
             cell.selectionStyle = UITableViewCellSelectionStyle.none
             return cell
         } else {
             let cell:SpeakerTableViewCell = tableView.dequeueReusableCell(withIdentifier: "speakerCell") as! SpeakerTableViewCell
-            
-            let speaker = speakers![indexPath.row] as DDATUserAccount
-            if let speakerDescription = (speaker.getProfile()) {
-                let imageUrl = speaker.avatarImageUrl() ?? ""
-                cell.loadInfo(speaker.getName()!, info: speakerDescription, imgUrl: imageUrl)
+            for speaker in speakers! {
+                if let speakerDescription = (speaker.getProfile()) {
+                    let imageUrl = speaker.avatarImageUrl() ?? ""
+                    cell.loadInfo(speaker.getName()!, info: speakerDescription, imgUrl: imageUrl)
+                }
             }
             
             cell.selectionStyle = UITableViewCellSelectionStyle.none

--- a/ios/ios/EventTableViewCell.swift
+++ b/ios/ios/EventTableViewCell.swift
@@ -19,15 +19,16 @@ class EventTableViewCell: UITableViewCell {
     var conflict: jboolean!
     var eventDetailPresenter: DPRESEventDetailViewModel!
     
-    func loadInfo(_ title: String, description: String, track: String, time: String, networkEvent: DDATEvent, eventDetailPresenter: DPRESEventDetailViewModel, conflict: jboolean?) {
+    func loadInfo(_ networkEvent: DDATEvent, eventDetailPresenter: DPRESEventDetailViewModel, conflict: jboolean?) {
         
         self.networkEvent = networkEvent
         self.conflict = conflict
         self.eventDetailPresenter = eventDetailPresenter
         
-        titleLabel.text = title.replacingOccurrences(of: "Android", with: "[Sad Puppy]")
-        timeInfoLabel.text = "Track " + track + ", " + time
-        descriptionLabel.text = description.replacingOccurrences(of: "/n/n", with: "/n")
+        titleLabel.text = networkEvent.getName().replacingOccurrences(of: "Android", with: "[Sad Puppy]")
+        let time = TimeUtils.getEventTime(startTime: networkEvent.getStartFormatted()! as NSString, andEnd: networkEvent.getEndFormatted()! as NSString)
+        timeInfoLabel.text = "Track " + networkEvent.getVenue().getName() + ", " + time
+        descriptionLabel.text = networkEvent.getDescription().replacingOccurrences(of: "/n/n", with: "/n")
 
         if networkEvent.isNow() {
             timeConflictLabel.isHidden = false

--- a/ios/ios/ScheduleViewController.swift
+++ b/ios/ios/ScheduleViewController.swift
@@ -74,10 +74,7 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
         if segue.identifier == "ShowEventDetail" {
             let detailViewController = segue.destination as! EventDetailViewController
             let networkEvent = sender as! DDATEvent
-            detailViewController.titleString = networkEvent.getName().replacingOccurrences(of: "Android", with: "[Sad Puppy]")
-            detailViewController.descriptionString = networkEvent.getDescription().replacingOccurrences(of: "Android", with: "[Sad Puppy]")
-            detailViewController.event = networkEvent
-            detailViewController.dateTime = getEventTime(startTime: networkEvent.getStartFormatted()! as NSString, andEnd: networkEvent.getEndFormatted()! as NSString)
+            detailViewController.eventId = networkEvent.getId()
         }
     }
     
@@ -124,33 +121,6 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
     func updateTableData() {
         hourBlocks.removeAll()
         hourBlocks.append(contentsOf: hourBlocksArray)
-    }
-    
-    func getEventTime(startTime: NSString, andEnd endTime: NSString) -> String {
-        var startLoc = 7
-        var endLoc = 7
-        var startLocCutoff = 0
-        
-        let startFirstDigit = (startTime as NSString).substring(with: NSMakeRange((startTime as NSString).length - 7, 1))
-        let endFirstDigit = (endTime as NSString).substring(with: NSMakeRange((endTime as NSString).length - 7, 1))
-        
-        if startFirstDigit == "0" {
-            startLoc = 6
-        }
-        if endFirstDigit == "0" {
-            endLoc = 6
-        }
-        
-        let startAmPm = startTime.substring(with: NSMakeRange(startTime.length - 2, 2))
-        let endAmPm = endTime.substring(with: NSMakeRange(endTime.length - 2, 2))
-        if startAmPm == endAmPm {
-            startLocCutoff = 2
-        }
-        
-        let startTimeStr = startTime.substring(with: NSMakeRange(startTime.length-startLoc, startLoc-startLocCutoff))
-        let endTimeStr = endTime.substring(with: NSMakeRange(endTime.length - endLoc, endLoc))
-        
-        return "\(startTimeStr) - \(endTimeStr)"
     }
     
     //MARK: TableView

--- a/ios/ios/ScheduleViewController.swift
+++ b/ios/ios/ScheduleViewController.swift
@@ -17,17 +17,11 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
     
     // MARK: Properties
     var isDayTwo: Bool = false
-    var dateFormatter: DateFormatter!
-    var timeFormatter: DateFormatter!
     var hourBlocks: [DPRESHourBlock]!
     var conferenceDays: [DPRESDaySchedule]?
     
-    var track: Int!
-    var notesArray: [String]!
-    var imagesArray: [UIImageView]!
     var conferencePresenter: DPRESConferenceDataViewModel!
     var schedulePresenter: DPRESScheduleDataViewModel!
-    var notes: JavaUtilArrayList!
     var allEvents = true
   
     var hourBlocksArray : [DPRESHourBlock] {
@@ -36,10 +30,6 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
         let index = isDayTwo ? 1 : 0
         if let days = conferenceDays, days.count > index, let objectArray = days[index].getHourHolders() {
             array.append(contentsOf: JavaUtils.convertiOSObjectArrayToArray(objArray: objectArray) as! [DPRESHourBlock])
-        }
-        if dateFormatter == nil {
-            dateFormatter = DateFormatter()
-            dateFormatter.dateFormat="hh:mma"
         }
         return array
     }
@@ -90,15 +80,6 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
         tableView.reloadData()
     }
     
-    func loadImage(with imagePath: String) {
-        let paths = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.documentDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)
-        let documentsDirectory = URL(fileURLWithPath: paths[0])
-        let path = documentsDirectory.appendingPathComponent(imagePath)
-        let image = UIImage(contentsOfFile: path.absoluteString)
-        let imageView = UIImageView(image: image)
-        imagesArray.append(imageView)
-    }
-    
     func loadCallback(withDPRESDayScheduleArray daySchedules: IOSObjectArray!) {
         hourBlocks = [DPRESHourBlock]()
         conferenceDays = JavaUtils.convertiOSObjectArrayToArray(objArray: daySchedules) as? [DPRESDaySchedule]
@@ -114,7 +95,6 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
     }
     
     func showEventDetailView(with networkEvent: DDATTimeBlock, andIndex index: Int) {
-        track = index
         performSegue(withIdentifier: "ShowEventDetail", sender: networkEvent)
     }
     
@@ -137,7 +117,9 @@ class ScheduleViewController : UIViewController, UITableViewDelegate, UITableVie
         
         let eventObj = hourBlocks[indexPath.row].getTime()
         if let networkEvent = eventObj {
-            showEventDetailView(with: networkEvent, andIndex: indexPath.row)
+            if networkEvent is DDATEvent {
+                showEventDetailView(with: networkEvent, andIndex: indexPath.row)
+            }
         }
     }
     

--- a/ios/ios/SpeakerTableViewCell.swift
+++ b/ios/ios/SpeakerTableViewCell.swift
@@ -14,6 +14,7 @@ class SpeakerTableViewCell: UITableViewCell {
     @IBOutlet weak var nameLabel : UILabel!
     @IBOutlet weak var infoLabel : UILabel!
     @IBOutlet weak var speakerImage: UIImageView!
+    @IBOutlet weak var speakerImageLabel: UILabel!
     
     func loadInfo(_ name: String, info: String, imgUrl: String) {
         nameLabel.text = name
@@ -21,13 +22,16 @@ class SpeakerTableViewCell: UITableViewCell {
         
         if (!imgUrl.isEmpty) {
             speakerImage.kf.setImage(with: URL(string: imgUrl)!)
+            speakerImage.layer.cornerRadius = 24
+            speakerImage.layer.masksToBounds = true
+        } else {
+            speakerImageLabel.text = DUTEmojiUtil.getEmojiForUser(with: name)
         }
-        speakerImage.layer.cornerRadius = 24
-        speakerImage.layer.masksToBounds = true
-        
+    
         nameLabel.sizeToFit()
         infoLabel.sizeToFit()
         speakerImage.sizeToFit()
+        speakerImageLabel.sizeToFit()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/ios/ios/SpeakerTableViewCell.swift
+++ b/ios/ios/SpeakerTableViewCell.swift
@@ -19,7 +19,9 @@ class SpeakerTableViewCell: UITableViewCell {
         nameLabel.text = name
         infoLabel.text = info//formatHTMLString(info)
         
-        speakerImage.kf.setImage(with: URL(string: imgUrl)!)
+        if (!imgUrl.isEmpty) {
+            speakerImage.kf.setImage(with: URL(string: imgUrl)!)
+        }
         speakerImage.layer.cornerRadius = 24
         speakerImage.layer.masksToBounds = true
         

--- a/ios/ios/SpeakerTableViewCell.xib
+++ b/ios/ios/SpeakerTableViewCell.xib
@@ -40,8 +40,24 @@
                             <constraint firstAttribute="width" constant="48" id="e4C-KL-Ti8"/>
                         </constraints>
                     </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p5V-VV-oSi">
+                        <rect key="frame" x="13" y="8" width="48" height="48"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                        </accessibility>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="48" id="1co-ad-5rz"/>
+                            <constraint firstAttribute="width" constant="48" id="95f-2J-71Z"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="p5V-VV-oSi" firstAttribute="centerX" secondItem="Kv0-F4-vGC" secondAttribute="centerX" id="0JG-Wf-qRR"/>
+                    <constraint firstItem="p5V-VV-oSi" firstAttribute="leading" secondItem="YcR-Cc-Hdz" secondAttribute="leadingMargin" constant="5" id="5Xc-Py-KJM"/>
+                    <constraint firstItem="p5V-VV-oSi" firstAttribute="centerY" secondItem="Kv0-F4-vGC" secondAttribute="centerY" id="7gi-WN-Qby"/>
                     <constraint firstAttribute="bottomMargin" secondItem="dmI-Z3-ba9" secondAttribute="bottom" id="DBB-4B-yc7"/>
                     <constraint firstAttribute="trailingMargin" secondItem="qCf-1y-7Lg" secondAttribute="trailing" id="JHk-2u-fLR"/>
                     <constraint firstItem="qCf-1y-7Lg" firstAttribute="leading" secondItem="Kv0-F4-vGC" secondAttribute="trailing" constant="13" id="M98-wd-U2e"/>
@@ -52,12 +68,14 @@
                     <constraint firstItem="dmI-Z3-ba9" firstAttribute="trailing" secondItem="qCf-1y-7Lg" secondAttribute="trailing" id="jS3-ZQ-rMu"/>
                     <constraint firstItem="Kv0-F4-vGC" firstAttribute="leading" secondItem="YcR-Cc-Hdz" secondAttribute="leadingMargin" constant="5" id="lvK-G9-FwG"/>
                     <constraint firstItem="qCf-1y-7Lg" firstAttribute="leading" secondItem="dmI-Z3-ba9" secondAttribute="leading" id="qb6-tw-JnS"/>
+                    <constraint firstItem="qCf-1y-7Lg" firstAttribute="leading" secondItem="Kv0-F4-vGC" secondAttribute="trailing" constant="13" id="w84-NJ-hu2"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="infoLabel" destination="dmI-Z3-ba9" id="XHG-tr-C9C"/>
                 <outlet property="nameLabel" destination="qCf-1y-7Lg" id="4UI-iw-9HN"/>
                 <outlet property="speakerImage" destination="Kv0-F4-vGC" id="kPR-cJ-tU3"/>
+                <outlet property="speakerImageLabel" destination="p5V-VV-oSi" id="bE0-Vt-ssn"/>
             </connections>
             <point key="canvasLocation" x="375" y="347"/>
         </tableViewCell>

--- a/ios/ios/SponsorImage.swift
+++ b/ios/ios/SponsorImage.swift
@@ -18,19 +18,16 @@ class SponsorItem : Equatable {
     
     var image : UIImage?
     let spanCount : Int
-    let sponsorName : String
     let sponsorImage : String
     let sponsorLink : String
-    
-    init (count:Int, name:String, image:String, link:String) {
+
+    init (count: Int, image: String, link: String) {
         self.spanCount = count
-        self.sponsorName = name
         self.sponsorImage = image
         self.sponsorLink = link
     }
     
     func loadImage(_ completion: @escaping (_ photo:SponsorItem, _ error: NSError?) -> Void) {
-        
         let sponsorImageUrl = URL(string: sponsorImage)
         let loadRequest = URLRequest(url:sponsorImageUrl!)
         let task = URLSession.shared.dataTask(with: loadRequest) { data, request, error in
@@ -58,7 +55,6 @@ class SponsorItem : Equatable {
         
         let imageSize = image!.size
         var returnSize = size
-        
         let aspectRatio = imageSize.width / imageSize.height
         
         returnSize.height = returnSize.width / aspectRatio
@@ -91,7 +87,7 @@ class Sponsor {
     
     let processingQueue = OperationQueue()
     
-    func getSponsorResults(_ sponsorType: Int, completion : @escaping (_ results: SponsorResults?, _ error : NSError?) -> Void){
+    func getSponsorResults(_ sponsorType: Int, completion : @escaping (_ results: SponsorResults?, _ error : NSError?) -> Void) {
         let searchURL = getSearchUrlForSponsorType(sponsorType)
         let searchRequest = URLRequest(url: searchURL)
         
@@ -110,16 +106,10 @@ class Sponsor {
                     for sponsorJson in sponsorArray {
                         
                         let spanCount = sponsorJson["spanCount"] as? Int
-                        let sponsorName = sponsorJson["sponsorName"] as? String
                         let sponsorImage = sponsorJson["sponsorImage"] as? String
                         let sponsorLink = sponsorJson["sponsorLink"] as? String
-                        
-                        let item = SponsorItem(
-                            count: spanCount!,
-                            name: sponsorName!,
-                            image: sponsorImage!,
-                            link: sponsorLink!)
-                        
+
+                        let item = SponsorItem(count: spanCount!, image: sponsorImage!, link: sponsorLink!)
                         sponsorItems += [item]
                     }
                 }

--- a/ios/ios/SponsorPhotoCell.swift
+++ b/ios/ios/SponsorPhotoCell.swift
@@ -9,6 +9,5 @@
 import UIKit
 
 class SponsorPhotoCell: UICollectionViewCell {
-    
     @IBOutlet weak var imageView: UIImageView!
 }

--- a/ios/ios/SponsorsViewController.swift
+++ b/ios/ios/SponsorsViewController.swift
@@ -8,15 +8,12 @@
 
 import UIKit
 
-private let reuseIdentifier = "Cell"
-
 class SponsorsViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     
     @IBOutlet weak var navBar: UINavigationBar!
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var tabs: UISegmentedControl!
     
-    fileprivate let reuseIdentifier = "SponsorPhotoCell"
     fileprivate let sectionInsets = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
     
     fileprivate var items = NSMutableDictionary()
@@ -73,14 +70,10 @@ class SponsorsViewController: UIViewController, UICollectionViewDataSource, UICo
             
                 self.collectionView?.reloadData()
             }
-            
         })
-
     }
     
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                               insetForSectionAt section: Int) -> UIEdgeInsets {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return sectionInsets
     }
     
@@ -101,7 +94,7 @@ class SponsorsViewController: UIViewController, UICollectionViewDataSource, UICo
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! SponsorPhotoCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SponsorPhotoCell", for: indexPath) as! SponsorPhotoCell
         
         cell.backgroundColor = UIColor.white
         cell.imageView.image = nil
@@ -112,7 +105,7 @@ class SponsorsViewController: UIViewController, UICollectionViewDataSource, UICo
         DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async {
             let data = try? Data(contentsOf: url!)
             DispatchQueue.main.async(execute: {
-                if(data != nil){
+                if (data != nil) {
                     cell.imageView.image = UIImage(data: data!)
                 }
             });
@@ -131,9 +124,7 @@ class SponsorsViewController: UIViewController, UICollectionViewDataSource, UICo
         return false
     }
     
-    func collectionView(_ collectionView: UICollectionView,
-                            layout collectionViewLayout: UICollectionViewLayout,
-                                   sizeForItemAt indexPath: IndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let photo = photoForIndexPath(indexPath)
         let paddingPerRow =  CGFloat(itemSpacing)  * (CGFloat(self.totalSpanCount) / CGFloat(photo.spanCount) - 1)
         let collectionSize = collectionView.bounds.size.width - sectionInsets.left - sectionInsets.right - paddingPerRow

--- a/ios/ios/TimeUtils.swift
+++ b/ios/ios/TimeUtils.swift
@@ -1,0 +1,38 @@
+//
+//  TimeUtils.swift
+//  ios
+//
+//  Created by Sufei Zhao on 8/17/17.
+//  Copyright © 2017 Kevin Galligan. All rights reserved.
+//
+
+import Foundation
+
+class TimeUtils {
+    static func getEventTime(startTime: NSString, andEnd endTime: NSString) -> String {
+        var startLoc = 7
+        var endLoc = 7
+        var startLocCutoff = 0
+        
+        let startFirstDigit = (startTime as NSString).substring(with: NSMakeRange((startTime as NSString).length - 7, 1))
+        let endFirstDigit = (endTime as NSString).substring(with: NSMakeRange((endTime as NSString).length - 7, 1))
+        
+        if startFirstDigit == "0" {
+            startLoc = 6
+        }
+        if endFirstDigit == "0" {
+            endLoc = 6
+        }
+        
+        let startAmPm = startTime.substring(with: NSMakeRange(startTime.length - 2, 2))
+        let endAmPm = endTime.substring(with: NSMakeRange(endTime.length - 2, 2))
+        if startAmPm == endAmPm {
+            startLocCutoff = 2
+        }
+        
+        let startTimeStr = startTime.substring(with: NSMakeRange(startTime.length-startLoc, startLoc-startLocCutoff))
+        let endTimeStr = endTime.substring(with: NSMakeRange(endTime.length - endLoc, endLoc))
+        
+        return "\(startTimeStr) - \(endTimeStr)"
+    }
+}

--- a/ios/ios/UIViewController.swift
+++ b/ios/ios/UIViewController.swift
@@ -21,6 +21,7 @@ extension UIViewController {
         if viewController.isKind(of: type) {
             return viewController
         }
+        
         if let presentedViewController = viewController.presentedViewController {
             // Return presented view controller
             return UIViewController.findBest(viewController: presentedViewController, forType: type)
@@ -32,7 +33,6 @@ extension UIViewController {
                 return viewController
             }
         } else if viewController.isKind(of: UINavigationController.self) {
-            
             //Return top view
             let navController = viewController as! UINavigationController
             if navController.viewControllers.count > 0 {
@@ -41,7 +41,6 @@ extension UIViewController {
                 return viewController
             }
         } else if viewController.isKind(of: UITabBarController.self) {
-            
             //Return visible view
             let tabController = viewController as! UITabBarController
             if let viewControllers = tabController.viewControllers, viewControllers.count > 0 {

--- a/ios/ios/WelcomePageViewController.swift
+++ b/ios/ios/WelcomePageViewController.swift
@@ -41,8 +41,7 @@ class WelcomePageViewController: UIPageViewController {
 
 extension WelcomePageViewController: UIPageViewControllerDataSource {
     
-    func pageViewController(_ pageViewController: UIPageViewController,
-                            viewControllerBefore viewController: UIViewController) -> UIViewController? {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let viewControllerIndex = orderedViewControllers.index(of: viewController) else {
             return nil
         }
@@ -61,8 +60,7 @@ extension WelcomePageViewController: UIPageViewControllerDataSource {
 
     }
     
-    func pageViewController(_ pageViewController: UIPageViewController,
-                            viewControllerAfter viewController: UIViewController) -> UIViewController? {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let viewControllerIndex = orderedViewControllers.index(of: viewController) else {
             return nil
         }
@@ -87,10 +85,7 @@ extension WelcomePageViewController: UIPageViewControllerDataSource {
 
 extension WelcomePageViewController: UIPageViewControllerDelegate {
     
-    func pageViewController(_ pageViewController: UIPageViewController,
-                            didFinishAnimating finished: Bool,
-                                               previousViewControllers: [UIViewController],
-                                               transitionCompleted completed: Bool) {
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if let firstViewController = viewControllers?.first,
             let index = orderedViewControllers.index(of: firstViewController) {
             welcomeDelegate?.welcomePageViewController(self,
@@ -102,9 +97,7 @@ extension WelcomePageViewController: UIPageViewControllerDelegate {
 
 protocol WelcomePageViewControllerDelegate: class {
     
-    func welcomePageViewController(_ welcomePageViewController: WelcomePageViewController,
-                                    didUpdatePageCount count: Int)
+    func welcomePageViewController(_ welcomePageViewController: WelcomePageViewController, didUpdatePageCount count: Int)
     
-    func welcomePageViewController(_ welcomePageViewController: WelcomePageViewController,
-                                    didUpdatePageIndex index: Int)
+    func welcomePageViewController(_ welcomePageViewController: WelcomePageViewController, didUpdatePageIndex index: Int)
 }


### PR DESCRIPTION
Firebase on iOS:
- same inputs as Android, refer to https://github.com/doppllib/DroidconDopplExample/pull/37 
- subscribed to "all_2017" and "ios_2017"
- refresh/version update gets called next time app is in foreground
- must set "content available" only if there is "notification" body

Currently, local notifications are in place, but aren't being calling since we don't have a button for alarms yet. Can easily be connected once we get updated designs.

Also fixed bugs I ran into:
- simulator showed navigation bar, but it didn't on actual device
- events with 2 speakers did not show update second speaker info
- app crashed when speaker has no image url
- app crashed when clicking on time blocks